### PR TITLE
Webpack mastery: Від препроцесорів до аналізатора

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,3 @@
->0.5%
-last 2 versions
-not dead
+defaults
+not ie <= 11
+maintained node versions

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2021: true, node: true },
+  parser: undefined,
+  parserOptions: { ecmaVersion: "latest", sourceType: "module" },
+  plugins: [],
+  extends: ["eslint:recommended"],
+  rules: {},
+};

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [["@babel/preset-env", { targets: "defaults" }]],
+};

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -2090,6 +2090,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "ideallyInert": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack serve --config webpack.config.js",
     "build": "cross-env NODE_ENV=production webpack --config webpack.config.js",
-    "preview": "npx http-server dist -p 4173 --silent"
+    "preview": "npx http-server dist -p 4173 --silent",
+    "analyze": "ANALYZE=true cross-env NODE_ENV=production webpack --config webpack.config.js",
+    "lint": "eslint \"src/**/*.{ts,tsx,js,jsx}\"",
+    "lint:fix": "eslint \"src/**/*.{ts,tsx,js,jsx}\" --fix"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",
@@ -21,5 +24,11 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "browserslist": [
+    "defaults",
+    "not ie <= 11",
+    "maintained node versions"
+  ]
 }
+

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require("autoprefixer")],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/webpack.common.cjs
+++ b/webpack.common.cjs
@@ -1,0 +1,41 @@
+const path = require("path");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const ESLintPlugin = require("eslint-webpack-plugin");
+const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
+
+module.exports = {
+  entry: path.resolve(process.cwd(), "src", "index.js"), // 👉 якщо TS — постав 'index.ts'
+  output: {
+    path: path.resolve(process.cwd(), "dist"),
+    filename: "assets/js/[name].[contenthash].js",
+    clean: true,
+    assetModuleFilename: "assets/media/[hash][ext][query]",
+  },
+  resolve: {
+    extensions: [".ts", ".tsx", ".js", ".jsx"],
+    alias: { "@": path.resolve(process.cwd(), "src") },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx|js|jsx)$/,
+        exclude: /node_modules/,
+        use: { loader: "babel-loader" },
+      },
+      {
+        test: /\.(png|jpe?g|gif|svg|webp)$/i,
+        type: "asset",
+        parser: { dataUrlCondition: { maxSize: 10 * 1024 } },
+      },
+      { test: /\.(woff2?|eot|ttf|otf)$/i, type: "asset/resource" },
+    ],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.resolve(process.cwd(), "public", "index.html"),
+      favicon: false,
+    }),
+    new ESLintPlugin({ extensions: ["ts", "tsx", "js", "jsx"] }),
+    new ForkTsCheckerWebpackPlugin(), // без TS теж ок — просто не запускає typecheck
+  ],
+};

--- a/webpack.dev.cjs
+++ b/webpack.dev.cjs
@@ -1,0 +1,33 @@
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.cjs");
+const path = require("path");
+
+module.exports = merge(common, {
+  mode: "development",
+  devtool: "eval-cheap-module-source-map",
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: ["style-loader", "css-loader", "postcss-loader"],
+      },
+      {
+        test: /\.s[ac]ss$/i,
+        use: ["style-loader", "css-loader", "postcss-loader", "sass-loader"],
+      },
+      {
+        test: /\.less$/i,
+        use: ["style-loader", "css-loader", "postcss-loader", "less-loader"],
+      },
+    ],
+  },
+  devServer: {
+    static: { directory: path.join(process.cwd(), "public") },
+    historyApiFallback: true,
+    compress: true,
+    open: true,
+    port: 3000,
+    hot: true,
+    client: { overlay: { errors: true, warnings: false } },
+  },
+});

--- a/webpack.prod.cjs
+++ b/webpack.prod.cjs
@@ -1,0 +1,53 @@
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.cjs");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
+const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
+
+const isAnalyze = process.env.ANALYZE === "true";
+
+module.exports = merge(common, {
+  mode: "production",
+  devtool: "source-map",
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [MiniCssExtractPlugin.loader, "css-loader", "postcss-loader"],
+      },
+      {
+        test: /\.s[ac]ss$/i,
+        use: [
+          MiniCssExtractPlugin.loader,
+          "css-loader",
+          "postcss-loader",
+          "sass-loader",
+        ],
+      },
+      {
+        test: /\.less$/i,
+        use: [
+          MiniCssExtractPlugin.loader,
+          "css-loader",
+          "postcss-loader",
+          "less-loader",
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: "assets/css/[name].[contenthash].css",
+    }),
+    ...(isAnalyze ? [new BundleAnalyzerPlugin()] : []),
+  ],
+  optimization: {
+    minimizer: [
+      new TerserPlugin({ extractComments: false }),
+      new CssMinimizerPlugin(),
+    ],
+    splitChunks: { chunks: "all" },
+    runtimeChunk: "single",
+  },
+});


### PR DESCRIPTION
У цій версіі Webpack mastery: Від препроцесорів до аналізатора маємо такі обновлення:

DevServer для автоматичного перезавантаження сторінки при змінах у коді.
Роботу з зовнішніх CSS файлів.
Підтримку препроцесорів, таких як LESS та Sass/SCSS.
Компіляцію TypeScript файлів.
Транспіляцію JavaScript коду за допомогою Babel.
Перевірку коду за допомогою Eslint.
Використання Webpack Bundle Analyzer для візуалізації розміру та змісту пакетів.